### PR TITLE
Test gem against ruby 2.0.0 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 1.9.2
   - 1.9.3
+  - 2.0.0
 gemfile:
   - Gemfile
 script: "bundle exec rake"


### PR DESCRIPTION
I'm using 2.0.0-p0 down here and I wasn't able to run tests because of
an issue while loading the fixtures, not sure it is related to the ruby
version but a pull request to fix that is on the way as well ;-)
