### PR TITLE
Ensure Freelancer model gets loaded before creating the Worker subclass when running specs

### DIFF
--- a/spec/fixtures/app/models/worker.rb
+++ b/spec/fixtures/app/models/worker.rb
@@ -1,3 +1,4 @@
+require 'freelancer'
 
 # Check custom STI
 class Worker < Freelancer

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,9 @@ load 'fixtures/schema.rb'
 
 root_dir = File.dirname(__FILE__)
 
+# Add our models to ruby load path
+$:.unshift("#{root_dir}/fixtures/app/models")
+
 # Load models
 Dir["#{root_dir}/fixtures/app/models/**/*.rb"].each { |f| require f}
 


### PR DESCRIPTION
I was hitting the error below when I tried to run the specs and this
should fix it :)

```
$ be rake

The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
/home/fabio/.rbenv/versions/2.0.0-p0/bin/ruby -S rspec ./spec/associations_index_spec.rb ./spec/common_function_spec.rb
-- create_table("users", {:force=>true})
-> 0.0049s
-- create_table("companies", {:force=>true})
  -> 0.0005s
-- add_index(:companies, :country_id)
  -> 0.0002s
  -- create_table("addresses", {:force=>true})
  -> 0.0005s
  -- create_table("freelancers", {:force=>true})
  -> 0.0004s
  -- create_table("timesheets", {:force=>true})
  -> 0.0004s
  -- create_table("complex_timesheets", {:force=>true})
  -> 0.0004s
  -- create_table("billable_weeks", {:force=>true})
  -> 0.0004s
  -- create_table("complex_billable_week", {:force=>true})
  -> 0.0004s
  -- create_table("companies_freelancers", {:id=>false, :force=>true})
  -> 0.0003s
  -- create_table("gifts", {:primary_key=>"custom_primary_key", :force=>true})
  -> 0.0003s
  -- create_table("purchases", {:id=>false, :force=>true})
  -> 0.0002s
  -- create_table("countries", {:force=>true})
  -> 0.0004s
  /home/fabio/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `require': cannot load such file -- freelancer (LoadError)
  from /home/fabio/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `block in require'
  from /home/fabio/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:236:in `load_dependency'
  from /home/fabio/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `require'
  from /home/projects/oss/lol_dba/spec/fixtures/app/models/worker.rb:1:in `<top (required)>'
  from /home/fabio/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `require'
  from /home/fabio/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `block in require'
  from /home/fabio/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:236:in `load_dependency'
  from /home/fabio/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `require'
  from /home/projects/oss/lol_dba/spec/spec_helper.rb:25:in `block in <top (required)>'
  from /home/projects/oss/lol_dba/spec/spec_helper.rb:25:in `each'
  from /home/projects/oss/lol_dba/spec/spec_helper.rb:25:in `<top (required)>'
  from /home/projects/oss/lol_dba/spec/associations_index_spec.rb:1:in `require'
  from /home/projects/oss/lol_dba/spec/associations_index_spec.rb:1:in `<top (required)>'
  from /home/fabio/.rbenv/gems/2.0.0/gems/rspec-core-2.12.2/lib/rspec/core/configuration.rb:789:in `load'
  from /home/fabio/.rbenv/gems/2.0.0/gems/rspec-core-2.12.2/lib/rspec/core/configuration.rb:789:in `block in load_spec_files'
  from /home/fabio/.rbenv/gems/2.0.0/gems/rspec-core-2.12.2/lib/rspec/core/configuration.rb:789:in `each'
  from /home/fabio/.rbenv/gems/2.0.0/gems/rspec-core-2.12.2/lib/rspec/core/configuration.rb:789:in `load_spec_files'
  from /home/fabio/.rbenv/gems/2.0.0/gems/rspec-core-2.12.2/lib/rspec/core/command_line.rb:22:in `run'
  from /home/fabio/.rbenv/gems/2.0.0/gems/rspec-core-2.12.2/lib/rspec/core/runner.rb:80:in `run'
  from /home/fabio/.rbenv/gems/2.0.0/gems/rspec-core-2.12.2/lib/rspec/core/runner.rb:17:in `block in autorun'
  rake aborted!
  /home/fabio/.rbenv/versions/2.0.0-p0/bin/ruby -S rspec ./spec/associations_index_spec.rb ./spec/common_function_spec.rb failed

  Tasks: TOP => default => spec
(See full trace by running task with --trace)
```
