### PR TITLE
Use absolute path when requiring the migration file and catch nil file_name in writer

### DIFF
--- a/lib/lol_dba/migration.rb
+++ b/lib/lol_dba/migration.rb
@@ -4,7 +4,7 @@ module LolDba
 
     def initialize(migration_file)
       self.full_name = File.basename(migration_file, ".rb")
-      require Rails.root + "db/migrate/#{full_name}.rb"
+      require Rails.root.join(migration_file)
     end
 
     def number

--- a/lib/lol_dba/writer.rb
+++ b/lib/lol_dba/writer.rb
@@ -17,6 +17,7 @@ module LolDba
       end
   
       def write(string)
+        return if file_name.nil?
         File.open(path, 'a') { |file| file << string; file << ";\n" }
       end
     end


### PR DESCRIPTION
The gem assumes that all migration files are directly within the db/migrate directory, so it is unable to load migration files within subdirectories. Modifying the initialize method in Migration class fixed that.

If the schema migrations table doesn't exist, errors occur because the redefine_execute_methods method only catches `SELECT "schema_migrations"."version"`, so Writer.file_name wasn't set. Writing to the migration_sql file only when the file_name isn't nil fixed that.
