### PR TITLE
Added support for ActiveRecord 4 migrator

### DIFF
--- a/lib/lol_dba/sql_generator.rb
+++ b/lib/lol_dba/sql_generator.rb
@@ -55,7 +55,12 @@ module LolDba
       end
     
       def migrations(which)
-        migrator = ActiveRecord::Migrator.new(:up, ActiveRecord::Migrator.migrations_path)
+        migrator = nil
+        if ActiveRecord.version.version =~ /^4./
+          migrator = ActiveRecord::Migrator.new(:up, ActiveRecord::Migrator.migrations(ActiveRecord::Migrator.migrations_path))
+        else
+          migrator = ActiveRecord::Migrator.new(:up, ActiveRecord::Migrator.migrations_path)
+        end
         if which == "all"
           migrator.migrations.collect { |m| m.filename }
         elsif which == "pending"


### PR DESCRIPTION
Active Record changed the initialiser of the migrator to accept the migration objects themselves rather than the path of the migration files.

This PR checks which version of active record is being used and changes how the initialisation of the migrator happens. 
