### PR TITLE
* Setup Travis for multi-version testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,22 @@
+# Send builds to container-based infrastructure
+# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
 language: ruby
 rvm:
-  - 2.2.1
-  - 2.1.5
+  - 2.0
+  - 2.1
+  - 2.2
+  - ruby-head
 gemfile:
-  - Gemfile
+  - gemfiles/rails_3_2.gemfile
+  - gemfiles/rails_4_0.gemfile
+  - gemfiles/rails_4_1.gemfile
+  - gemfiles/rails_4_2.gemfile
 script: "bundle exec rake"
 notifications:
   recipients:
     - diego@plentz.org
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: ruby-head


### PR DESCRIPTION
* Enable faster Travis build
* Specify ruby versions with less restrictive alias, allowing using the latest patch level of ruby automatically
* Also test for ruby-head but allow failure