### PR TITLE
allow to use this on non-rails applications that use active_record

### DIFF
--- a/lib/lol_dba.rb
+++ b/lib/lol_dba.rb
@@ -72,7 +72,9 @@ EOM
   end
 
   def self.check_for_indexes(migration_format = false)
-    Rails.application.eager_load! unless Rails.env.test?
+    if defined?(Rails) && !Rails.env.test?
+      Rails.application.eager_load!
+    end
 
     model_classes = []
     ObjectSpace.each_object(Module) do |obj|


### PR DESCRIPTION
I was recently working on a sinatra + AR application and needed to use this gem. 
Since the `check_for_indexes` method refers explicitly to `Rails`, I couldn't run the rake task.
I did this little fix to enable it to use with Sinatra (or any other app that uses AR outside Rails)

I hope it's helpful to someone else