### PR TITLE
Make example naming consistent

### DIFF
--- a/lib/lol_dba.rb
+++ b/lib/lol_dba.rb
@@ -6,7 +6,7 @@ module LolDba
 
   def self.form_migration_content(migration_name, index_array)
     migration = <<EOM
-* run `rails g migration AddMissingIndexes` and add the following content:
+* run `rails g migration #{migration_name}` and add the following content:
 
 
     class #{migration_name} < ActiveRecord::Migration


### PR DESCRIPTION
Fix small bug related to https://github.com/plentz/lol_dba/issues/55

Where ```form_migration_content ``` was using the hard coded name "AddMissingIndexes" instead of the provided ```migration_name```.