### PR TITLE
Fix ActiveRecord version check for Rails 3

### DIFF
--- a/lib/lol_dba/sql_generator.rb
+++ b/lib/lol_dba/sql_generator.rb
@@ -56,7 +56,7 @@ module LolDba
     
       def migrations(which)
         migrator = nil
-        if ActiveRecord.version.version =~ /^4./
+        if ActiveRecord.respond_to?(:version) && ActiveRecord.version.version =~ /^4./
           migrator = ActiveRecord::Migrator.new(:up, ActiveRecord::Migrator.migrations(ActiveRecord::Migrator.migrations_path))
         else
           migrator = ActiveRecord::Migrator.new(:up, ActiveRecord::Migrator.migrations_path)

--- a/lib/lol_dba/sql_generator.rb
+++ b/lib/lol_dba/sql_generator.rb
@@ -56,7 +56,7 @@ module LolDba
     
       def migrations(which)
         migrator = nil
-        if ActiveRecord.respond_to?(:version) && ActiveRecord.version.version =~ /^4./
+        if ::ActiveRecord::VERSION::MAJOR =~ /^4./
           migrator = ActiveRecord::Migrator.new(:up, ActiveRecord::Migrator.migrations(ActiveRecord::Migrator.migrations_path))
         else
           migrator = ActiveRecord::Migrator.new(:up, ActiveRecord::Migrator.migrations_path)


### PR DESCRIPTION
It seems `ActiveRecord.version` was only added in Rails 4, so this
causes a `NoMethodError` on Rails 3.