### PR TITLE
Travis: update CI matrix to 2.2.7, 2.3.4, 2.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
   - ruby-head
 gemfile:
   - gemfiles/rails_3_2.gemfile


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.