### PR TITLE
CI: Drop unused setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 env:
   global:
     - CC_TEST_REPORTER_ID=46e5fb2273e7c6fb1beaad7c0f14ad898f0eed65d98a20c80fe8eb4e216a7ff0
-sudo: false
 language: ruby
 cache: bundler
 before_install:


### PR DESCRIPTION
-  Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration