### PR TITLE
Fixed issue with options hash not being returned in lol_dba CLI appli…

### DIFF
--- a/lib/lol_dba/cli.rb
+++ b/lib/lol_dba/cli.rb
@@ -20,6 +20,7 @@ module LolDba
             exit
           end
         end.parse!
+        options
       end
     end
 


### PR DESCRIPTION
Returned options hash from within `parse_options` method in CLI application. See Issue #110 