### PR TITLE
Don't search for indices on classes without tables

### DIFF
--- a/lib/lol_dba/index_finding/index_finder.rb
+++ b/lib/lol_dba/index_finding/index_finder.rb
@@ -68,7 +68,7 @@ module LolDba
 
     def self.model_classes
       ActiveRecord::Base.descendants.select do |obj|
-        Class == obj.class && session_store?(obj)
+        Class == obj.class && session_store?(obj) && obj.table_exists?
       end
     end
 


### PR DESCRIPTION
The `LolDba::IndexFinder` was iterating over all subclasses of `ActiveRecord::Base`, including abstract classes that don't have backing tables in the DB (namely ActionText and ActionMailbox).

This change simply omits classes without backing tables from the search for missing indices.

Resolves #146